### PR TITLE
Feat: Allow configuration using environment variables 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:alpine as builder
 RUN apk add --no-cache git build-base
-RUN go get -v github.com/swordbeta/trello-burndown/...
+ENV GOBIN=$GOPATH/bin
+COPY . /go
+WORKDIR /go/cmd
+RUN go get -v && go install
 
 FROM alpine
 RUN apk add --no-cache ca-certificates

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/spf13/viper"
@@ -21,8 +22,10 @@ func init() {
 	viper.SetConfigName("config")
 	err = viper.ReadInConfig()
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 	}
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/spf13/viper"
 	"github.com/swordbeta/trello-burndown/pkg/server"

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -1,7 +1,10 @@
 trello:
     apiKey: # See README on how to get the api key
     userToken: # See README on how to get the user token
-    refreshRate: 30 # minutes
+    refreshRate: 30 # Minutes
+database:
+    dialect: sqlite3 # Currently supported values: sqlite3 or postgres     
+    url: ./trello.db # Example for remote connection: postgresql://user:pass@host:5432/trello?connect_timeout=5
 http:
     port: 8080
     baseURL: http://localhost:8080/ # With trailing slash

--- a/pkg/trello/database.go
+++ b/pkg/trello/database.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jinzhu/gorm"
+	"github.com/spf13/viper"
 )
 
 // Board contains data of a trello board.
@@ -30,7 +31,7 @@ type CardProgress struct {
 
 // GetDatabase returns a sqlite3 database connection.
 func GetDatabase() *gorm.DB {
-	db, err := gorm.Open("sqlite3", "./trello.db")
+	db, err := gorm.Open(viper.GetString("database.dialect"), viper.GetString("database.url"))
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Hi, 
I use the dockerized version of your trello-burndown (which is great by the way!) and thought it would be nice to use environment variables for configuration instead of config file (so I don't bother creating volumes) Using environment variables also allows to use a remote database (I use postgresql instead of sqlite)
Hope this can help.